### PR TITLE
adding a build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+version: 1.0.{build}
+os: Visual Studio 2015 RC
+
+configuration: Release
+
+build_script:
+  - ps: .\build.ps1
+
+artifacts:
+  - path: '**\*.vsix'

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,37 @@
+[cmdletbinding()]
+param()
+
+function Get-ScriptDirectory{
+    split-path (((Get-Variable MyInvocation -Scope 1).Value).MyCommand.Path)
+}
+$scriptDir = ((Get-ScriptDirectory) + "\")
+
+<#
+.SYNOPSIS
+    Will make sure that psbuild is installed and loaded. If not it will
+    be downloaded.
+#>
+function EnsurePsbuildInstlled{
+    [cmdletbinding()]
+    param(
+        [string]$psbuildInstallUri = 'https://raw.githubusercontent.com/ligershark/psbuild/master/src/GetPSBuild.ps1'
+    )
+    process{
+        # if psbuild is not available
+        if(-Not (Get-Command "Invoke-MsBuild" -errorAction SilentlyContinue)){
+            'Installing psbuild from [{0}]' -f $psbuildInstallUri | Write-Verbose
+            (new-object Net.WebClient).DownloadString($psbuildInstallUri) | iex
+        }
+        else{
+            'psbuild already loaded' | Write-Verbose
+        }
+    }
+}
+
+[System.IO.FileInfo]$slnfile = (Join-Path $scriptDir '.\Fast Koala.sln')
+
+# begin script
+EnsurePsbuildInstlled
+'Restoring nuget packages for [''{0}'']' -f $slnfile.FullName | Write-Host
+&nuget restore "$($slnfile.FullName)"
+Invoke-MSBuild -projectsToBuild $slnfile.FullName -visualStudioVersion 14.0 -properties @{'DeployExtension'='false'}


### PR DESCRIPTION
Adding `build.ps1` which can be used to build the vsix file in a PowerShell prompt. I've also added `appveyor.yml` so that you can hook this up to appveyor and get the generated vsix automatically uploaded as an artifact.

I've created an appveyor build from my fork, the links are below.
- [latest build](https://ci.appveyor.com/project/sayedihashimi/fastkoala)
- [artifacts](https://ci.appveyor.com/project/sayedihashimi/fastkoala/build/1.0.2/artifacts)
